### PR TITLE
Add pcntl extension and improve installation of others

### DIFF
--- a/php-dev-8.dockerfile
+++ b/php-dev-8.dockerfile
@@ -165,6 +165,11 @@ COPY php/* /opt/php-libs/files/
 # activate opcache and jit
 RUN mv /opt/php-libs/files/opcache-jit.ini /usr/local/etc/php/conf.d/docker-php-opcache-jit.ini
 
+# install pcntl
+RUN cd /opt/php-libs \
+    && docker-php-ext-configure pcntl --enable-pcntl \
+    && docker-php-ext-install pcntl 
+
 # install pcov
 RUN cd /opt/php-libs \
     && git clone https://github.com/krakjoe/pcov.git \

--- a/php-dev-8.dockerfile
+++ b/php-dev-8.dockerfile
@@ -192,7 +192,7 @@ RUN git clone --depth 1 https://github.com/tideways/php-xhprof-extension /usr/sr
 RUN curl https://raw.githubusercontent.com/git/git/v$(git --version | awk 'NF>1{print $NF}')/contrib/completion/git-completion.bash > /root/.git-completion.bash \
     && curl https://raw.githubusercontent.com/git/git/v$(git --version | awk 'NF>1{print $NF}')/contrib/completion/git-prompt.sh > /root/.git-prompt.sh
 RUN mkdir -p /var/log/supervisord
-EXPOSE 80 443 9000
+EXPOSE 80 443 9003
 CMD ["/usr/bin/supervisord", "-nc", "/opt/docker/supervisord.conf"]
 
 WORKDIR /app

--- a/php-dev-8.dockerfile
+++ b/php-dev-8.dockerfile
@@ -44,7 +44,7 @@ RUN apk add --no-cache \
 RUN addgroup -S nginx \
     && adduser -D -S -h /var/cache/nginx -s /sbin/nologin -G nginx nginx
 RUN addgroup -g $APPLICATION_GID $APPLICATION_GROUP \
-    && echo '%application ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/application \
+    && echo "%$APPLICATION_GROUP ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/$APPLICATION_GROUP \
     && adduser -D -u $APPLICATION_UID -s /bin/bash -G $APPLICATION_GROUP $APPLICATION_USER
 
 RUN mkdir -p /usr/src \
@@ -163,7 +163,7 @@ RUN mkdir -p /opt/php-libs
 COPY php/* /opt/php-libs/files/
 
 # activate opcache and jit
-RUN mv /opt/php-libs/files/opcache-jit.ini /usr/local/etc/php/conf.d/docker-php-opcache-jit.ini
+RUN mv /opt/php-libs/files/opcache-jit.ini "$PHP_INI_DIR/conf.d/docker-php-opcache-jit.ini"
 
 # install pcntl
 RUN docker-php-ext-configure pcntl --enable-pcntl \
@@ -185,7 +185,7 @@ RUN cd /opt/php-libs \
     && phpize \
     && ./configure --enable-xdebug-dev \
     && make all \
-    && mv /opt/php-libs/files/xdebug.ini /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
+    && mv /opt/php-libs/files/xdebug.ini "$PHP_INI_DIR/conf.d/docker-php-ext-xdebug.ini" \
     && mkdir /tmp/debug \
     && chmod -R 777 /tmp/debug
 

--- a/php-dev-8.dockerfile
+++ b/php-dev-8.dockerfile
@@ -176,18 +176,11 @@ RUN git clone --depth 1 https://github.com/krakjoe/pcov.git /usr/src/php/ext/pco
     && mv /opt/php-libs/files/pcov.ini "$PHP_INI_DIR/conf.d/docker-php-pcov.ini"
 
 # install xdebug 3.0
-RUN cd /opt/php-libs \
-    && wget https://github.com/xdebug/xdebug/archive/$XDEBUG_VERSION.tar.gz \
-    && mkdir xdebug && tar -zxC ./xdebug -f $XDEBUG_VERSION.tar.gz --strip-components 1 \
-    && rm  $XDEBUG_VERSION.tar.gz \
-    && cd xdebug \
-    # the last working commit, because the php-src is not up to date yet in this alpine
-    && phpize \
-    && ./configure --enable-xdebug-dev \
-    && make all \
+RUN git clone -b $XDEBUG_VERSION --depth 1 https://github.com/xdebug/xdebug.git /usr/src/php/ext/xdebug \
+    && docker-php-ext-configure xdebug --enable-xdebug-dev \
     && mv /opt/php-libs/files/xdebug.ini "$PHP_INI_DIR/conf.d/docker-php-ext-xdebug.ini" \
-    && mkdir /tmp/debug \
-    && chmod -R 777 /tmp/debug
+    && docker-php-ext-install xdebug \
+    && mkdir /tmp/debug
 
 # install tideways
 RUN git clone --depth 1 https://github.com/tideways/php-xhprof-extension /usr/src/php/ext/xhprof \

--- a/php-dev-8.dockerfile
+++ b/php-dev-8.dockerfile
@@ -166,20 +166,14 @@ COPY php/* /opt/php-libs/files/
 RUN mv /opt/php-libs/files/opcache-jit.ini /usr/local/etc/php/conf.d/docker-php-opcache-jit.ini
 
 # install pcntl
-RUN cd /opt/php-libs \
-    && docker-php-ext-configure pcntl --enable-pcntl \
-    && docker-php-ext-install pcntl 
+RUN docker-php-ext-configure pcntl --enable-pcntl \
+    && docker-php-ext-install pcntl
 
 # install pcov
-RUN cd /opt/php-libs \
-    && git clone https://github.com/krakjoe/pcov.git \
-    && cd pcov \
-    && phpize \
-    && ./configure --enable-pcov \
-    && make \
-    && make install \
-    && docker-php-ext-enable pcov \
-    && mv /opt/php-libs/files/pcov.ini /usr/local/etc/php/conf.d/docker-php-pcov.ini
+RUN git clone --depth 1 https://github.com/krakjoe/pcov.git /usr/src/php/ext/pcov \
+    && docker-php-ext-configure pcov --enable-pcov \
+    && docker-php-ext-install pcov \
+    && mv /opt/php-libs/files/pcov.ini "$PHP_INI_DIR/conf.d/docker-php-pcov.ini"
 
 # install xdebug 3.0
 RUN cd /opt/php-libs \
@@ -196,15 +190,11 @@ RUN cd /opt/php-libs \
     && chmod -R 777 /tmp/debug
 
 # install tideways
-RUN cd /opt/php-libs \
-     && git clone https://github.com/tideways/php-xhprof-extension \
-     && cd php-xhprof-extension \
-     && phpize \
-     && ./configure \
-     && make \
-     && make install \
-     && mkdir -p /opt/docker/profiler \
-     && mv /opt/php-libs/files/xhprof.ini /usr/local/etc/php/conf.d/docker-php-ext-xhprof.ini
+RUN git clone --depth 1 https://github.com/tideways/php-xhprof-extension /usr/src/php/ext/xhprof \
+    && docker-php-ext-configure xhprof \
+    && docker-php-ext-install xhprof \
+    && mkdir -p /opt/docker/profiler \
+    && mv /opt/php-libs/files/xhprof.ini "$PHP_INI_DIR/conf.d/docker-php-ext-xhprof.ini"
 
 RUN curl https://raw.githubusercontent.com/git/git/v$(git --version | awk 'NF>1{print $NF}')/contrib/completion/git-completion.bash > /root/.git-completion.bash \
     && curl https://raw.githubusercontent.com/git/git/v$(git --version | awk 'NF>1{print $NF}')/contrib/completion/git-prompt.sh > /root/.git-prompt.sh

--- a/php/xdebug.ini
+++ b/php/xdebug.ini
@@ -1,5 +1,4 @@
 # @see https://3.xdebug.org/docs/all_settings
-zend_extension=/opt/php-libs/xdebug/modules/xdebug.so
 xdebug.mode=profile,develop,coverage
 # xdebug.client_host =
 xdebug.client_port=9003

--- a/php/xhprof.ini
+++ b/php/xhprof.ini
@@ -1,2 +1,1 @@
-extension=tideways_xhprof.so
 #auto_prepend_file=/opt/php-libs/files/profiler.php


### PR DESCRIPTION
PHP 8 will remove the pcntl extension from core so it has to be installed manually to get the timing functionality working in phpsu/ShellCommandBuilder#17. While figuring out how to do that, I noticed the other extension steps could also be improved so it's a slightly bigger PR than planned.

### Change Summary

* Added pcntl extension
* Added `--depth 1` to all `git clone` commands
   * Should help with image size (#3) by not fetching history
* Replaced all `cd $ext && phpize && ./configure --foo` with `docker-php-ext-configure $ext --foo`
* Replaced all `make && make install [&& docker-php-ext-enable]` with `docker-php-ext-install`
* Removed `[zend_]extension=foo.so` lines from xhprof and xdebug configs
   * These are appended automatically by `docker-php-ext-install`
* Updated exposed docker port to match that in php/xdebug.ini

The helper scripts can be found in [docker-library/php](https://github.com/docker-library/php/tree/0f0ddeac8b53fa936d870f56589abcf5646b65a8/8.0-rc/alpine3.12/fpm).